### PR TITLE
Make Civetweb use atomic operations for STOP_FLAG

### DIFF
--- a/cmake/civetweb-3rdparty-config.cmake
+++ b/cmake/civetweb-3rdparty-config.cmake
@@ -27,6 +27,8 @@ target_compile_definitions(civetweb
     NO_CGI
     NO_CACHING
     NO_FILES
+    USE_SERVER_STATS
+    STOP_FLAG_NEEDS_LOCK
 )
 
 target_compile_options(civetweb


### PR DESCRIPTION
On our CV machines we've seen mg_stop() of Civetweb hang due to it not
seeing the state of the stop flag change to value 2. To fix this ensure
we're using atomic read/write functions. Which is enable by setting the
defs STOP_FLAG_NEEDS_LOCK and to enable the functions
STOP_FLAG_NEEDS_LOCK needs set USE_SERVER_STATS.