### PR TITLE
pull: expose the endpoint meta collectable (v1.2.1)

### DIFF
--- a/cmake/civetweb-3rdparty-config.cmake
+++ b/cmake/civetweb-3rdparty-config.cmake
@@ -33,6 +33,8 @@ target_compile_definitions(civetweb
     NO_CACHING
     NO_FILES
     SOCKET_TIMEOUT_QUANTUM=200
+    USE_SERVER_STATS
+    STOP_FLAG_NEEDS_LOCK
 )
 
 target_compile_options(civetweb

--- a/pull/include/prometheus/exposer.h
+++ b/pull/include/prometheus/exposer.h
@@ -43,6 +43,9 @@ class PROMETHEUS_CPP_PULL_EXPORT Exposer {
   void RemoveCollectable(const std::weak_ptr<Collectable>& collectable,
                          const std::string& uri = std::string("/metrics"));
 
+  std::weak_ptr<Collectable> GetMetaCollectable(
+      const std::string& uri = std::string("/metrics"));
+
   std::vector<int> GetListeningPorts() const;
 
  private:

--- a/pull/src/endpoint.cc
+++ b/pull/src/endpoint.cc
@@ -49,5 +49,9 @@ void Endpoint::RemoveCollectable(
 
 const std::string& Endpoint::GetURI() const { return uri_; }
 
+std::weak_ptr<Registry> Endpoint::GetMetaRegistry() const {
+  return endpoint_registry_;
+}
+
 }  // namespace detail
 }  // namespace prometheus

--- a/pull/src/endpoint.h
+++ b/pull/src/endpoint.h
@@ -30,6 +30,7 @@ class Endpoint {
   void RemoveCollectable(const std::weak_ptr<Collectable>& collectable);
 
   const std::string& GetURI() const;
+  std::weak_ptr<Registry> GetMetaRegistry() const;
 
  private:
   CivetServer& server_;

--- a/pull/src/exposer.cc
+++ b/pull/src/exposer.cc
@@ -47,6 +47,12 @@ void Exposer::RemoveCollectable(const std::weak_ptr<Collectable>& collectable,
   endpoint.RemoveCollectable(collectable);
 }
 
+std::weak_ptr<Collectable> Exposer::GetMetaCollectable(const std::string& uri) {
+  std::lock_guard<std::mutex> lock{mutex_};
+  auto& endpoint = GetEndpointForUri(uri);
+  return endpoint.GetMetaRegistry();
+}
+
 std::vector<int> Exposer::GetListeningPorts() const {
   return server_->getListeningPorts();
 }

--- a/pull/tests/integration/integration_test.cc
+++ b/pull/tests/integration/integration_test.cc
@@ -201,6 +201,24 @@ TEST_F(IntegrationTest, shouldSendBodyAsUtf8) {
   EXPECT_THAT(metrics.contentType, HasSubstr("utf-8"));
 }
 
+TEST_F(IntegrationTest, removeMetaCollectable) {
+  const std::string counter_name = "example_total";
+  auto registry = RegisterSomeCounter(counter_name, default_metrics_path_);
+
+  const auto metrics = FetchMetrics(default_metrics_path_);
+  ASSERT_THAT(metrics.body, HasSubstr("example_total"));
+  ASSERT_THAT(metrics.body, HasSubstr("exposer_transferred_bytes_total"));
+
+  auto metaCollectable = exposer_->GetMetaCollectable(default_metrics_path_);
+  exposer_->RemoveCollectable(metaCollectable, default_metrics_path_);
+  ASSERT_FALSE(metaCollectable.expired());
+
+  const auto metricsNoMeta = FetchMetrics(default_metrics_path_);
+  EXPECT_THAT(metricsNoMeta.body, HasSubstr("example_total"));
+  EXPECT_THAT(metricsNoMeta.body,
+              Not(HasSubstr("exposer_transferred_bytes_total")));
+}
+
 class BasicAuthIntegrationTest : public IntegrationTest {
  public:
   void SetUp() override {


### PR DESCRIPTION
Allows the endpoint registry containing the "exposer_" prefixed metrics to be accessed, in order to be removed or wrapped by our code.

Also rebased our patch for v0.10.0 (Make Civetweb use atomic operations for STOP_FLAG) on top of v1.2.1.
